### PR TITLE
Fix for Android TV D-pad for Single Choice Lists such as Theme Selection

### DIFF
--- a/app/src/main/java/com/aefyr/sai/ui/dialogs/SingleChoiceListDialogFragment.java
+++ b/app/src/main/java/com/aefyr/sai/ui/dialogs/SingleChoiceListDialogFragment.java
@@ -128,7 +128,9 @@ public class SingleChoiceListDialogFragment extends BaseBottomSheetDialogFragmen
         @NonNull
         @Override
         public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-            return new ViewHolder(mInflater.inflate(R.layout.item_single_choice_dialog, parent, false));
+            View v = mInflater.inflate(R.layout.item_single_choice_dialog, parent, false);
+            v.requestFocus();
+            return new ViewHolder(v);
         }
 
         @Override


### PR DESCRIPTION
Fix for Android TV D-pad for Single Choice Lists such as Theme Selection.

I've had a look over your custom Bottom Sheet and recyclerview and found that the list was NOT requesting focus which is needed for the D-Pad on Android TV. I have fixed this in this pull request. I have also tested this on both the Android Phone and Android TV Pie Emulators and can confirm it works without breaking the selection for touch screen devices.