### PR TITLE
Additional Dpad Fix for Android TV

### DIFF
--- a/app/src/main/java/com/aefyr/sai/adapters/BackupNameFormatBuilderPartsAdapter.java
+++ b/app/src/main/java/com/aefyr/sai/adapters/BackupNameFormatBuilderPartsAdapter.java
@@ -69,6 +69,7 @@ public class BackupNameFormatBuilderPartsAdapter extends SelectableAdapter<Backu
 
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
+            itemView.requestFocus();
 
             ((Chip) itemView).setOnCheckedChangeListener((buttonView, isChecked) -> {
                 if (mPauseCheckedListener)

--- a/app/src/main/java/com/aefyr/sai/adapters/ThemeAdapter.java
+++ b/app/src/main/java/com/aefyr/sai/adapters/ThemeAdapter.java
@@ -78,6 +78,7 @@ public class ThemeAdapter extends RecyclerView.Adapter<ThemeAdapter.ViewHolder> 
 
         private ViewHolder(@NonNull View itemView) {
             super(itemView);
+            itemView.requestFocus();
 
             mCard = itemView.findViewById(R.id.container_theme_wrapper);
             mTitle = itemView.findViewById(R.id.tv_theme_title);


### PR DESCRIPTION
Additional Dpad Fix for Android TV, this fixes the 2 recyclerview preferences that are using adapters (Theme Selection and Backup Name Format). Tested on both Android Mobile and Android TV Emulators.

Its also a pity Google wont approve the Android TV Version on the playstore but if the Android TV parts of SAI can be maintained here on Github it would be great and i'm happy to help with minor fixes and testing of it.