### PR TITLE
DarkLight Theme Selection Dialog Dpad Fix for Android TV

### DIFF
--- a/app/src/main/java/com/aefyr/sai/ui/dialogs/DarkLightThemeSelectionDialogFragment.java
+++ b/app/src/main/java/com/aefyr/sai/ui/dialogs/DarkLightThemeSelectionDialogFragment.java
@@ -103,6 +103,8 @@ public class DarkLightThemeSelectionDialogFragment extends BaseBottomSheetDialog
         mViewModel.getLightTheme().observe(this, lightThemeView::setTheme);
         mViewModel.getDarkTheme().observe(this, darkThemeView::setTheme);
 
+        view.requestFocus();
+
         revealBottomSheet();
     }
 


### PR DESCRIPTION
DarkLight Theme Selection Dialog Dpad Fix for Android TV.

I guess this was overlooked again with testing on Android TV. I primary use it on Android TV hence why I am able to test if all the UI features are working at intended. 👍 

While Android TV 10 (Q) is NOT available at the moment and the Auto Theme aint auto switching yet due to the system integration, it will be in future Android TV Versions and good to have this already fixed.