### PR TITLE
getSystemProperty return string

### DIFF
--- a/app/src/main/java/com/aefyr/sai/utils/MiuiUtils.java
+++ b/app/src/main/java/com/aefyr/sai/utils/MiuiUtils.java
@@ -73,7 +73,7 @@ public class MiuiUtils {
 
     @SuppressLint("PrivateApi")
     public static boolean isMiuiOptimizationDisabled() {
-        if ("0".equals(Utils.getSystemProperty("persist.sys.miui_optimization")))
+        if ("false".equals(Utils.getSystemProperty("persist.sys.miui_optimization")))
             return true;
 
         try {


### PR DESCRIPTION
![13324614-9BC8-40C0-8FF3-4ECF166670CF](https://user-images.githubusercontent.com/11311447/96099412-ca680580-0f05-11eb-8fea-232974bb16ee.png)

`Utils.getSystemProperty("persist.sys.miui_optimization")` return String value is "true" or "false" rather than "0" or "1"