### PR TITLE
Fix Root/Shizuku installer installing in both personal and work profiles

### DIFF
--- a/app/src/main/java/com/aefyr/sai/installer/ShellSAIPackageInstaller.java
+++ b/app/src/main/java/com/aefyr/sai/installer/ShellSAIPackageInstaller.java
@@ -133,8 +133,8 @@ public abstract class ShellSAIPackageInstaller extends SAIPackageInstaller {
             commandsToAttempt.add(new Shell.Command(command, args.toArray(new String[0])));
             Logs.d(TAG, "Using custom install-create command: " + customInstallCreateCommand);
         } else {
-            commandsToAttempt.add(new Shell.Command("pm", "install-create", "-r", "--install-location", installLocation, "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
-            commandsToAttempt.add(new Shell.Command("pm", "install-create", "-r", "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
+            commandsToAttempt.add(new Shell.Command("pm", "install-create", "--user current", "-r", "--install-location", installLocation, "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
+            commandsToAttempt.add(new Shell.Command("pm", "install-create", "--user current", "-r", "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
         }
 
 

--- a/app/src/main/java/com/aefyr/sai/installer2/impl/shell/ShellSaiPackageInstaller.java
+++ b/app/src/main/java/com/aefyr/sai/installer2/impl/shell/ShellSaiPackageInstaller.java
@@ -189,8 +189,8 @@ public abstract class ShellSaiPackageInstaller extends BaseSaiPackageInstaller {
             commandsToAttempt.add(new Shell.Command(command, args.toArray(new String[0])));
             Logs.d(tag(), "Using custom install-create command: " + customInstallCreateCommand);
         } else {
-            commandsToAttempt.add(new Shell.Command("pm", "install-create", "-r", "--install-location", installLocation, "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
-            commandsToAttempt.add(new Shell.Command("pm", "install-create", "-r", "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
+            commandsToAttempt.add(new Shell.Command("pm", "install-create", "--user current", "-r", "--install-location", installLocation, "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
+            commandsToAttempt.add(new Shell.Command("pm", "install-create", "--user current", "-r", "-i", getShell().makeLiteral(BuildConfig.APPLICATION_ID)));
         }
 
 


### PR DESCRIPTION
Fixes issue #229 by adding the --user current flag to the pm install-create command.
Tested on shizuku but the fix should also apply for root users (I don't have the possibility to test)